### PR TITLE
Multiple organizations

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,5 @@
 {
   "watch": ["src"],
   "ext": "ts",
-  "ignore": ["src/public"],
   "exec": "ts-node ./src/server.ts"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-ts": "node ./utils/build.js",
     "postinstall": "npm run build-ts",
     "lint": "tslint --project \"tsconfig.json\"",
-    "start-dev": "nodemon --config \"./src/utils/nodemon.json\""
+    "start-dev": "nodemon --config"
   },
   "engines": {
     "node": "12.12.0"

--- a/src/views/callback.ejs
+++ b/src/views/callback.ejs
@@ -8,7 +8,7 @@
       <div class='body-wrapper'>
         <div class='body-content'>
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
-            <h2 id='authenticated'>You are authenticated!</h2>
+            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant %></span></h4>
             <hr>
             <h4>Id Token Data:</h2>
             <pre>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -8,7 +8,7 @@
       <div class='body-wrapper'>
         <div class='body-content'>
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
-            <h2 id='authenticated'>You are authenticated!</h2>
+            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant %></span></h4>
             <hr>
             <h4>Id Token Data:</h2>
             <pre>

--- a/src/views/shared/head.ejs
+++ b/src/views/shared/head.ejs
@@ -164,11 +164,42 @@
       width: 50%;
       padding: 20px;
     }
-    
+
+    #change-org {
+      position: relative;
+      float: right;
+    }
+
+    #change-org input {
+      -webkit-appearance: none;
+      height: 30px;
+      background-color:#FFF;
+      color:#666;
+      font-weight:bold;
+      border: solid #666 1px;
+      border-radius: 5px;
+      font-size: 14px;
+    }
+
+    .select-box {
+      height: 40px;
+      font-size: 13px;
+      max-width: 150px;
+      letter-spacing: 1px;
+    }
+
+
     /* Extra fun  */
     #authenticated {
       margin: 25px;
     }
+    #authenticated span {
+      font-weight: 10;
+      font-size: 15px;
+      letter-spacing: 2px;
+      margin-left: 10px;
+    }
+
     @-webkit-keyframes fadeinout {
       0%,100% { opacity: 0; height: 20px; }
       50% { opacity: 1; }

--- a/src/views/shared/header.ejs
+++ b/src/views/shared/header.ejs
@@ -1,9 +1,25 @@
 <header>
-  <% if (typeof(consentUrl) !== 'undefined' && consentUrl && typeof(authenticated) !== 'undefined') { %>
+  <% const loggedIn = typeof(authenticated.allTenants) !== 'undefined' && authenticated.allTenants %>
+
+  <% if ((typeof(consentUrl) !== 'undefined' && consentUrl && typeof(authenticated) !== 'undefined') || !loggedIn) { %>
     <a href="<%= consentUrl %>">
       <img src='https://developer.xero.com/static/images/documentation/ConnectToXero2019/connect-blue.svg'>
     </a>
-  <% } else{ %>  
+  <% } else { %>  
     <a href='/'><img src='https://www.xero.com/etc/designs/xero-cms/clientlib/assets/img/logo/logo-xero-blue.svg'></a>
   <% } %>
+
+
+  <% if (loggedIn) { %>
+    <form method='POST' action="/change_organisation" id="change-org">
+      <select name='active_org_id' class="select-box">
+        <% for(var i=0; i < authenticated.allTenants.length; i++) { %>
+          <% var selected = authenticated.allTenants[i] === authenticated.activeTenant ? "selected" : "" %>
+          <option <%=selected %> value=<%= authenticated.allTenants[i] %>> <%= authenticated.allTenants[i] %></option>
+          <% } %>
+        </select>
+        <input type="submit" class="select-input" value="Change Org">
+    </form>
+  <% } %>
+
 </header>


### PR DESCRIPTION
## Oauth2
The auth changes now enable a single user who has multiple orgs to authenticate at the top level, versus oauth1 apps that had you make direct authentication for a single one of your orgs.

Enable the tutorial to store the `activeTenant` in session and allow that to be changed, so if your user is active in multiple Xero orgs, you are able to interact with the tutorial by switching around..

SDK needs improvement of giving us back the org name in addition to just the UUID which would increase helpfulness of Xero API development for folks with multiple orgs.