### PR TITLE
Client refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "module-alias": "^2.2.2",
     "nodemon": "^1.19.4",
     "path": "^0.12.7",
-    "xero-node": "/Users/chris.knight/code/sdks/xero-node/xero-node-4.3.0.tgz"
+    "xero-node": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "module-alias": "^2.2.2",
     "nodemon": "^1.19.4",
     "path": "^0.12.7",
-    "xero-node": "4.2.0"
+    "xero-node": "/Users/chris.knight/code/sdks/xero-node/xero-node-4.3.0.tgz"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -44,22 +44,9 @@ import {
   TrackingCategories,
   TrackingCategory,
   TrackingOption,
-<<<<<<< HEAD
-  CurrencyCode,
-  Receipt,
-  Receipts,
-  PurchaseOrder,
-  PurchaseOrders,
-  Prepayment,
-  Allocation,
-  Allocations,
-  HistoryRecords,
-  PaymentServices,
   XeroIdToken,
-  XeroAccessToken
-=======
+  XeroAccessToken,
   XeroClient,
->>>>>>> master
 } from "xero-node";
 import Helper from "./helper";
 import jwtDecode from 'jwt-decode';

--- a/src/app.ts
+++ b/src/app.ts
@@ -127,7 +127,7 @@ class App {
         const tokenSet: TokenSet = await xero.apiCallback(req.url);
         await xero.updateTenants()
 
-        // this is where you can save your
+        // this is where you can associate & save your
         // `tokenSet` to a user in your Database
         const decodedIdToken: XeroIdToken = jwtDecode(tokenSet.id_token);
         const decodedAccessToken: XeroAccessToken = jwtDecode(tokenSet.access_token)

--- a/src/views/callback.ejs
+++ b/src/views/callback.ejs
@@ -4,7 +4,7 @@
     if(window.confirm("WARNING! This sample application will Create, Read, Update & Delete REAL objects in your Xero Database. Please only use a Demo company or test organisation.")) {
       console.log('welcome to the tutorial :)')
     } else {
-      window.location.assign('/logout')
+      window.location.assign('/disconnect')
     }
   }, 500)
 </script>
@@ -18,6 +18,14 @@
         <div class='body-content'>
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
             <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.orgData.name %></span></h4>
+            <hr>
+            <h4>Active Tenant:</h2>
+            <pre>
+              <code class='language-javascript'>
+                <%- JSON.stringify(authenticated.activeTenant.orgData, null, 2).replace(/[{}]/g, '') %>
+              </code>
+            </pre>
+            <hr>
             <hr>
             <h4>Access Token Data:</h2>
               <pre>

--- a/src/views/callback.ejs
+++ b/src/views/callback.ejs
@@ -17,7 +17,7 @@
       <div class='body-wrapper'>
         <div class='body-content'>
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
-            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.meta.name %></span></h4>
+            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.orgData.name %></span></h4>
             <hr>
             <h4>Access Token Data:</h2>
               <pre>

--- a/src/views/callback.ejs
+++ b/src/views/callback.ejs
@@ -17,7 +17,7 @@
       <div class='body-wrapper'>
         <div class='body-content'>
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
-            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant %></span></h4>
+            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.meta.name %></span></h4>
             <hr>
             <h4>Access Token Data:</h2>
               <pre>

--- a/src/views/callback.ejs
+++ b/src/views/callback.ejs
@@ -22,10 +22,9 @@
             <h4>Active Tenant:</h2>
             <pre>
               <code class='language-javascript'>
-                <%- JSON.stringify(authenticated.activeTenant.orgData, null, 2).replace(/[{}]/g, '') %>
+                <%- JSON.stringify(authenticated.activeTenant.orgData, null, 2).replace(/[{}]/g, '').substring(0, 300) + ' ...' %>
               </code>
             </pre>
-            <hr>
             <hr>
             <h4>Access Token Data:</h2>
               <pre>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -13,7 +13,7 @@
             <h4>Active Tenant:</h2>
             <pre>
               <code class='language-javascript'>
-                <%- JSON.stringify(authenticated.activeTenant.orgData, null, 2).replace(/[{}]/g, '') %>
+                <%- JSON.stringify(authenticated.activeTenant.orgData, null, 2).replace(/[{}]/g, '').substring(0, 300) + ' ...' %>
               </code>
             </pre>
             <hr>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -8,7 +8,7 @@
       <div class='body-wrapper'>
         <div class='body-content'>
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
-            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant %></span></h4>
+            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.meta.name %></span></h4>
             <hr>
             <h4>Access Token Data:</h2>
             <pre>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -10,6 +10,13 @@
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
             <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.orgData.name %></span></h4>
             <hr>
+            <h4>Active Tenant:</h2>
+            <pre>
+              <code class='language-javascript'>
+                <%- JSON.stringify(authenticated.activeTenant.orgData, null, 2).replace(/[{}]/g, '') %>
+              </code>
+            </pre>
+            <hr>
             <h4>Access Token Data:</h2>
             <pre>
               <code class='language-javascript'>

--- a/src/views/home.ejs
+++ b/src/views/home.ejs
@@ -8,7 +8,7 @@
       <div class='body-wrapper'>
         <div class='body-content'>
           <% if (authenticated.decodedIdToken && authenticated.decodedAccessToken) { %>
-            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.meta.name %></span></h4>
+            <h4 id='authenticated'>You are authenticated with: <span><%= authenticated.activeTenant.orgData.name %></span></h4>
             <hr>
             <h4>Access Token Data:</h2>
             <pre>

--- a/src/views/shared/head.ejs
+++ b/src/views/shared/head.ejs
@@ -187,7 +187,7 @@
     .select-box {
       height: 30px;
       font-size: 13px;
-      max-width: 150px;
+      max-width: 275px;
       letter-spacing: 1px;
     }
 

--- a/src/views/shared/header.ejs
+++ b/src/views/shared/header.ejs
@@ -20,8 +20,8 @@
       <form method='POST' action="/change_organisation">
         <select name='active_org_id' class="select-box">
           <% for(var i=0; i < authenticated.allTenants.length; i++) { %>
-            <% var selected = authenticated.allTenants[i] === authenticated.activeTenant ? "selected" : "" %>
-            <option <%=selected %> value=<%= authenticated.allTenants[i] %>> <%= authenticated.allTenants[i] %></option>
+            <% var selected = authenticated.allTenants[i].tenantId === authenticated.activeTenant.tenantId ? "selected" : "" %>
+            <option <%= selected %> value=<%= authenticated.allTenants[i].tenantId %>> <%= authenticated.allTenants[i].meta.name %></option>
             <% } %>
           </select>
           <input type="submit" class="select-input" value="Change Org">

--- a/src/views/shared/header.ejs
+++ b/src/views/shared/header.ejs
@@ -12,9 +12,11 @@
 
   <% if (loggedIn) { %>
     <div class='nav-settings'>
-      <a href="/disconnect">
-        <input type="submit" class="select-input" value="Disconnect Tenant">
-      </a>
+      <% if (authenticated.allTenants.length > 1) { %>
+        <a href="/disconnect">
+          <input type="submit" class="select-input" value="Disconnect Tenant">
+        </a>
+      <% } %>
     </div>
     <div class='nav-settings'>
       <a href="/refresh-token">

--- a/src/views/shared/header.ejs
+++ b/src/views/shared/header.ejs
@@ -12,6 +12,11 @@
 
   <% if (loggedIn) { %>
     <div class='nav-settings'>
+      <a href="/disconnect">
+        <input type="submit" class="select-input" value="Disconnect Tenant">
+      </a>
+    </div>
+    <div class='nav-settings'>
       <a href="/refresh-token">
         <input type="submit" class="select-input" value="Refresh Token">
       </a>

--- a/src/views/shared/header.ejs
+++ b/src/views/shared/header.ejs
@@ -21,7 +21,7 @@
         <select name='active_org_id' class="select-box">
           <% for(var i=0; i < authenticated.allTenants.length; i++) { %>
             <% var selected = authenticated.allTenants[i].tenantId === authenticated.activeTenant.tenantId ? "selected" : "" %>
-            <option <%= selected %> value=<%= authenticated.allTenants[i].tenantId %>> <%= authenticated.allTenants[i].meta.name %></option>
+            <option <%= selected %> value=<%= authenticated.allTenants[i].tenantId %>> <%= authenticated.allTenants[i].orgData.name %></option>
             <% } %>
           </select>
           <input type="submit" class="select-input" value="Change Org">


### PR DESCRIPTION
Changelog from xero-node PR
--------

## "version": "4.4.0"
> Jumping past vsn 4.3.0 to indicate the breaking changes without having to increment a major release as well as leaving room for development on the previous client configuration

#### Had significant community feedback that the documentation and initial auth was too complex.. This refactor is a simplification of the `xeroClient.ts` naming and an expansion of functionality around the non-generated SDK code.

Breaking Changes:
* `setAccessTokenFromRedirectUri` renamed as `apiCallback`
* `buildClient()` remove from constructor, and those responsibilities were moved to an initializer function which must be called once the XeroClient is constructed due to some asyncronous setup required by the [openid-client](https://github.com/panva/node-openid-client):
	* Example:
		```js
		const xero = new XeroClient({...config})
		xero.initialize()
		```
* Added a `disconnect()` function
* Added a `updateTenants()` function which populates the tenant's organisation details behind during the authentication process and greatly reduces the complexity of showing org details by eliminating the need for developers to make additional calls the the `/organisation` endpoint for each connected tenant
* Added types for XeroAccessToken and XeroIdToken to show usable data that the access & id tokens may contain.